### PR TITLE
chore: add node 22 and 23 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        nodejs: ['12', '14', '16', '18', '20', '21']
+        nodejs: ['12', '14', '16', '18', '20', '21', '22', '23']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "webpack-merge": "^5.8.0"
       },
       "engines": {
-        "node": ">=12.10 <=21",
-        "npm": ">=7.0 <10"
+        "node": ">=12.10",
+        "npm": ">=7.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "prepare": "npm run build:browser"
   },
   "engines": {
-    "node": ">=12.10 <=21",
-    "npm": ">=7.0 <10"
+    "node": ">=12.10",
+    "npm": ">=7.0"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
And drop unnecessary upper constraints for npm and nodejs versions